### PR TITLE
Advanced command execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
         </repository>
 
         <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -105,6 +110,13 @@
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/jasonhorkles/expensivedeaths/Execution.java
+++ b/src/main/java/me/jasonhorkles/expensivedeaths/Execution.java
@@ -1,0 +1,177 @@
+package me.jasonhorkles.expensivedeaths;
+
+import com.google.common.base.Suppliers;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+public abstract class Execution {
+
+    private static final Supplier<Boolean> USE_PLACEHOLDERAPI = Suppliers.memoize(() -> Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"));
+    private static final Pattern KEY_CHANCE = Pattern.compile("(?i)(test-?)?(chance|prob(ability)?)");
+    private static final Pattern KEY_CANCEL = Pattern.compile("(?i)break|stop|cancel(ling)?");
+    private static final Pattern KEY_PERMISSION = Pattern.compile("(?i)(meet-?)?perm(ission)?");
+    private static final Pattern KEY_EXECUTION = Pattern.compile("(?i)run|(run-?)?(cmds?|commands?)|execut(e|ions?)");
+
+    public static Execution of(Object object) {
+        if (object instanceof String) {
+            return new SimpleExecution((String) object);
+        } else if (object instanceof Iterable) {
+            final List<Execution> executions = new ArrayList<>();
+            for (Object o : (Iterable<?>) object) {
+                final Execution execution = of(o);
+                if (execution != null) {
+                    executions.add(execution);
+                }
+            }
+            if (!executions.isEmpty()) {
+                return new AdvancedExecution(0.0, false, null, executions);
+            }
+        } else if (object instanceof Map) {
+            double chance = 0.0;
+            boolean cancelling = false;
+            String permission = null;
+            final List<Execution> executions = new ArrayList<>();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) object).entrySet()) {
+                final String key = String.valueOf(entry.getKey());
+                final Object value = entry.getValue();
+                if (KEY_CHANCE.matcher(key).matches()) {
+                    try {
+                        chance = Double.parseDouble(String.valueOf(value));
+                    } catch (NumberFormatException ignored) { }
+                } else if (KEY_CANCEL.matcher(key).matches()) {
+                    cancelling = String.valueOf(value).equalsIgnoreCase("true");
+                } else if (KEY_PERMISSION.matcher(key).matches()) {
+                    permission = String.valueOf(value);
+                } else if (KEY_EXECUTION.matcher(key).matches()) {
+                    final Execution execution = of(value);
+                    if (execution != null) {
+                        executions.add(execution);
+                    }
+                }
+            }
+            if (!executions.isEmpty()) {
+                return new AdvancedExecution(chance, cancelling, permission, executions);
+            }
+        }
+        return null;
+    }
+
+    public boolean run(Player player, Player agent, Function<String, String> parser) {
+        return run(player, agent, parser, false);
+    }
+
+    public boolean run(Player player, Player agent, Function<String, String> parser, boolean console) {
+        return run(console ? Bukkit.getConsoleSender() : player, player, agent, parser);
+    }
+
+    public abstract boolean run(CommandSender sender, Player player, Player agent, Function<String, String> parser);
+
+    public void run(CommandSender sender, Player player, Player agent, String cmd, Function<String, String> parser) {
+        String s = parser.apply(cmd);
+        if (USE_PLACEHOLDERAPI.get() && ExpensiveDeaths.getInstance().getConfig().getBoolean("parse-placeholders", false)) {
+            s = PlaceholderAPI.setPlaceholders(player, s);
+            if (agent != null) {
+                s = PlaceholderAPI.setBracketPlaceholders(agent, s);
+            }
+        }
+        Bukkit.dispatchCommand(sender, s);
+    }
+
+    public static class SimpleExecution extends Execution {
+
+        private final String cmd;
+
+        public SimpleExecution(String cmd) {
+            this.cmd = cmd;
+        }
+
+        public String getCmd() {
+            return cmd;
+        }
+
+        @Override
+        public boolean run(CommandSender sender, Player player, Player agent, Function<String, String> parser) {
+            this.run(sender, player, agent, cmd, parser);
+            return false;
+        }
+    }
+
+    public static class AdvancedExecution extends Execution {
+
+        private final double chance;
+        private final boolean cancelling;
+        private final String permission;
+        private final List<Execution> executions;
+
+        public AdvancedExecution(double chance, boolean cancelling, String permission, List<Execution> executions) {
+            this.chance = chance;
+            this.cancelling = cancelling;
+            this.permission = permission;
+            this.executions = executions;
+        }
+
+        public double getChance() {
+            return chance;
+        }
+
+        public String getPermission() {
+            return permission;
+        }
+
+        public List<Execution> getExecutions() {
+            return executions;
+        }
+
+        public boolean isCancelling() {
+            return cancelling;
+        }
+
+        public boolean testChance() {
+            return this.chance == 0.0 || ThreadLocalRandom.current().nextDouble() <= this.chance;
+        }
+
+        public boolean meetPermission(Player player) {
+            if (this.permission != null) {
+                for (String s : this.permission.split(";")) {
+                    if (!player.hasPermission(s)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean run(CommandSender sender, Player player, Player agent, Function<String, String> parser) {
+            if (!testChance() || !meetPermission(player)) {
+                return false;
+            }
+
+            for (Execution execution : executions) {
+                if (execution.run(sender, player, agent, parser)) {
+                    break;
+                }
+            }
+
+            return isCancelling();
+        }
+    }
+
+    public enum Type {
+        DEATH_PLAYER, DEATH_CONSOLE, KILL_PLAYER, KILL_CONSOLE, RESPAWN_PLAYER, RESPAWN_CONSOLE;
+
+        public boolean isConsole() {
+            return this == DEATH_CONSOLE || this == KILL_CONSOLE || this == RESPAWN_CONSOLE;
+        }
+    }
+}

--- a/src/main/java/me/jasonhorkles/expensivedeaths/ExpensiveDeaths.java
+++ b/src/main/java/me/jasonhorkles/expensivedeaths/ExpensiveDeaths.java
@@ -6,9 +6,14 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class ExpensiveDeaths extends JavaPlugin implements Listener, CommandExecutor {
     public static ExpensiveDeaths getInstance() {
@@ -16,6 +21,7 @@ public class ExpensiveDeaths extends JavaPlugin implements Listener, CommandExec
     }
 
     private Economy econ;
+    private final Map<Execution.Type, Execution> executions = new HashMap<>();
     private static ExpensiveDeaths instance;
 
     @Override
@@ -24,6 +30,7 @@ public class ExpensiveDeaths extends JavaPlugin implements Listener, CommandExec
 
         setupEconomy();
         saveDefaultConfig();
+        loadExecutions();
 
         getServer().getPluginManager().registerEvents(new DeathEvent(this), this);
         getServer().getPluginManager().registerEvents(new RespawnEvent(this), this);
@@ -32,12 +39,20 @@ public class ExpensiveDeaths extends JavaPlugin implements Listener, CommandExec
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         saveDefaultConfig();
         reloadConfig();
+        loadExecutions();
         sender.sendMessage(ChatColor.GREEN + "ExpensiveDeaths reloaded!");
         return true;
     }
 
     public Economy getEconomy() {
         return econ;
+    }
+
+    public void run(Execution.Type type, Player player, Player agent, Function<String, String> parser) {
+        final Execution execution = this.executions.get(type);
+        if (execution != null) {
+            execution.run(player, agent, parser, type.isConsole());
+        }
     }
 
     private void setupEconomy() {
@@ -47,5 +62,22 @@ public class ExpensiveDeaths extends JavaPlugin implements Listener, CommandExec
             .getRegistration(Economy.class);
         if (rsp == null) return;
         econ = rsp.getProvider();
+    }
+
+    private void loadExecutions() {
+        this.executions.clear();
+        loadExecution(Execution.Type.DEATH_CONSOLE, "console-commands-on-death");
+        loadExecution(Execution.Type.DEATH_PLAYER, "player-commands-on-death");
+        loadExecution(Execution.Type.KILL_CONSOLE, "console-commands-on-kill");
+        loadExecution(Execution.Type.KILL_PLAYER, "player-commands-on-kill");
+        loadExecution(Execution.Type.RESPAWN_CONSOLE, "console-commands-on-respawn");
+        loadExecution(Execution.Type.RESPAWN_PLAYER, "player-commands-on-respawn");
+    }
+
+    private void loadExecution(Execution.Type type, String key) {
+        final Execution execution = Execution.of(getConfig().get("bonus." + key));
+        if (execution != null) {
+            this.executions.put(type, execution);
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,12 +23,17 @@ currency-format: "#,##0.00"
 # Or see https://www.iso.org/obp for all Alpha-2 country codes
 currency-country: US
 
+# Set true to parse placeholders from PlaceholderAPI inside commands
+parse-placeholders: false
+
 
 
 # Additional features not related to economy
 bonus:
   # Use {PLAYER} for the player's username
   # Use {DISPLAYNAME} for the player's display name
+  # Use {MONEY} to display the money they lost
+  # Use {BALANCE} to display the player's remaining balance
   
   # Commands run by console when a player dies
   console-commands-on-death:
@@ -37,6 +42,16 @@ bonus:
   
   # Commands run by the player when they die
   player-commands-on-death:
+  #- "command 1"
+  #- "command 2"
+
+  # Commands run by console when a player was killed by other player
+  console-commands-on-kill:
+  #- "command 1"
+  #- "command 2"
+
+  # Commands run by the player when they die by other player
+  player-commands-on-kill:
   #- "command 1"
   #- "command 2"
 


### PR DESCRIPTION
### Additions
* `parse-placeholders` option to parse PlaceholderAPI placeholders on commands.
* Commands when player was killed by other player.
* Added #3 using advanced commands.

### Advanced commands
The actual way to configure commands is via String list:
```yaml
list:
  - 'command1'
  - 'command2'
  - 'command3'
```
With advanced commands you can set various options:
`chance` - A chance to execute, for example `chance: 0.75` for 75%
`permission` - A permission to execute, for example `permission: perm.123` (You can set multiple permissions separated by `;`)
`break` - To cancel the execution from the next commands in the list, for example `break: true`
`run` - The command or list of commands to execute.
For example:
```yaml
list:
  - 'command1'
  - chance: 0.35
    break: true
    run: 'command2'
  - chance: 0.60
    permission: 'perm.asd.123'
    run:
      - 'command3'
      - 'command4'
  - permission: 'other.perm'
    run:
      - 'command5'
      - chance: 0.40
        run: 'command6'
      - 'command7'
  - 'command8'
```